### PR TITLE
Added support for M1 Macs

### DIFF
--- a/Example/Gemfile
+++ b/Example/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "cocoapods", "1.10.1"
+gem 'rexml', '~> 3.2.4'

--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    activesupport (5.2.4.5)
+    activesupport (5.2.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -54,14 +54,14 @@ GEM
     colored2 (3.1.2)
     concurrent-ruby (1.1.8)
     escape (0.0.4)
-    ethon (0.12.0)
-      ffi (>= 1.3.0)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
     ffi (1.15.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     minitest (5.14.4)
@@ -70,6 +70,7 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     public_suffix (4.0.6)
+    rexml (3.2.5)
     ruby-macho (1.4.0)
     thread_safe (0.3.6)
     typhoeus (1.4.0)
@@ -88,6 +89,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.10.1)
+  rexml (~> 3.2.4)
 
 BUNDLED WITH
-   2.1.4
+   2.2.16

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Forge (1.0.6)
-  - Satin (1.3.3)
+  - Satin (1.3.4)
 
 DEPENDENCIES:
   - Forge (from `https://github.com/Hi-Rez/Forge.git`)
@@ -19,7 +19,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Forge: 51249d32e43237a51047404ff698dc633f3ac584
-  Satin: eac366eb30a0280243051f87a46a1133e3789f8d
+  Satin: c8b8c80e461918ab3ab8a03f1138a54cb0172fda
 
 PODFILE CHECKSUM: bc341e917d00f27bf46c14ec90c98f56e60359ab
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Satin is a 3D graphics framework (inspired by threejs) that helps designers and 
 
 ## Getting Started
 
+> If you're using a Mac with an **M1 Chip**, you may need to do a new install of Ruby. You can follow [this guide](https://gorails.com/setup/osx/11.0-big-sur) up until "Configuring Git" to do so. 
+
 Install Bundler using:
 
 ```


### PR DESCRIPTION
This PR fixes the errors associated with cocoapods/bundler caused by old dependencies in the lock files, and adds documentation for installing a new version of Ruby if neccesary. 