### PR TITLE
simplify RayMarched example

### DIFF
--- a/Example/Source/Shared/RayMarching/Assets/Pipelines/RayMarched/Shaders.metal
+++ b/Example/Source/Shared/RayMarching/Assets/Pipelines/RayMarched/Shaders.metal
@@ -65,6 +65,8 @@ vertex RayMarchedData rayMarchedVertex( Vertex in [[stage_in]],
     const float4x4 inverseViewMatrix = uniforms.inverseViewMatrix;
     const float4x4 inverseModelViewProjectionMatrix = uniforms.inverseModelViewProjectionMatrix;
 
+    // See https://www.iquilezles.org/www/articles/raypolys/raypolys.htm
+
     const float c = projectionMatrix[2].z;
     const float d = projectionMatrix[3].z;
     const float near = d / c;

--- a/Example/Source/Shared/Shipping/Helper.metal
+++ b/Example/Source/Shared/Shipping/Helper.metal
@@ -150,6 +150,7 @@ typedef struct {
     matrix_float4x4 modelViewMatrix;
     matrix_float4x4 projectionMatrix;
     matrix_float4x4 modelViewProjectionMatrix;
+    matrix_float4x4 inverseModelViewProjectionMatrix;
     matrix_float4x4 inverseViewMatrix;
     matrix_float3x3 normalMatrix;
     float3 worldCameraPosition;

--- a/Sources/Satin/Core/Mesh.swift
+++ b/Sources/Satin/Core/Mesh.swift
@@ -103,6 +103,7 @@ open class Mesh: Object, GeometryDelegate {
             vertexUniforms[0].modelViewMatrix = simd_mul(vertexUniforms[0].viewMatrix, vertexUniforms[0].modelMatrix)
             vertexUniforms[0].projectionMatrix = camera.projectionMatrix
             vertexUniforms[0].modelViewProjectionMatrix = simd_mul(camera.viewProjectionMatrix, vertexUniforms[0].modelMatrix)
+            vertexUniforms[0].inverseModelViewProjectionMatrix = simd_inverse(vertexUniforms[0].modelViewProjectionMatrix)
             vertexUniforms[0].inverseViewMatrix = camera.worldMatrix
             vertexUniforms[0].normalMatrix = normalMatrix
             vertexUniforms[0].viewport = viewport

--- a/Sources/Satin/Pipelines/Satin/VertexUniforms.metal
+++ b/Sources/Satin/Pipelines/Satin/VertexUniforms.metal
@@ -4,6 +4,7 @@ typedef struct {
     matrix_float4x4 modelViewMatrix;
     matrix_float4x4 projectionMatrix;
     matrix_float4x4 modelViewProjectionMatrix;
+    matrix_float4x4 inverseModelViewProjectionMatrix;
     matrix_float4x4 inverseViewMatrix;
     matrix_float3x3 normalMatrix;
     float4 viewport;

--- a/Sources/Satin/Types/VertexUniforms.swift
+++ b/Sources/Satin/Types/VertexUniforms.swift
@@ -14,6 +14,7 @@ public struct VertexUniforms {
     public var modelViewMatrix: float4x4
     public var projectionMatrix: float4x4
     public var modelViewProjectionMatrix: float4x4
+    public var inverseModelViewProjectionMatrix: float4x4
     public var inverseViewMatrix: float4x4
     public var normalMatrix: float3x3
     public var viewport: simd_float4


### PR DESCRIPTION
Simplify the RayMarched example using the inverse of the `modelViewProjectionMatrix`. By not relying on uv coordinates this generalizes ray-marching to any bounding geometry (in the example, it would be more efficient to ray-march the front faces of a bounding cube rather than the entire viewport, which would matter for more computationally intensive scenes).

If we could pass the modelViewProjectionMatrix to the fragment function we could further simplify. It wasn't clear to me how to do that given that `RayMarchedMaterial.bind` doesn't have access to the matrix.