### PR TITLE
Add performance test for getAdaptiveQuadraticBezierPath2

### DIFF
--- a/Tests/SatinCoreTests/BezierTests.swift
+++ b/Tests/SatinCoreTests/BezierTests.swift
@@ -68,7 +68,6 @@ class BezierTests: XCTestCase {
         let cVel = normalize(quadraticBezierVelocity2(a, b, c, 1.0));
 
         var pts: [SIMD2<Float>] = []
-        pts.reserveCapacity(513)
         pts.append(a)
 
         _adaptiveQuadBezierCurve2(a, b, c, aVel, bVel, cVel, angleLimit, 0, &pts);

--- a/Tests/SatinCoreTests/BezierTests.swift
+++ b/Tests/SatinCoreTests/BezierTests.swift
@@ -1,0 +1,21 @@
+//
+//  BezierTests.swift
+//  
+//
+//  Created by Taylor Holliday on 3/23/22.
+//
+
+import XCTest
+import SatinCore
+
+class BezierTests: XCTestCase {
+
+    func testAdaptiveQuadraticBezierPath2Perf() {
+        self.measure {
+            var polyline = getAdaptiveQuadraticBezierPath2(.init(0, 0), .init(1,0), .init(0,1), 0.001)
+            XCTAssertEqual(polyline.count, 513)
+            freePolyline2D(&polyline)
+        }
+    }
+
+}

--- a/Tests/SatinCoreTests/BezierTests.swift
+++ b/Tests/SatinCoreTests/BezierTests.swift
@@ -7,14 +7,82 @@
 
 import XCTest
 import SatinCore
+import simd
 
 class BezierTests: XCTestCase {
 
     func testAdaptiveQuadraticBezierPath2Perf() {
         self.measure {
-            var polyline = getAdaptiveQuadraticBezierPath2(.init(0, 0), .init(1,0), .init(0,1), 0.001)
-            XCTAssertEqual(polyline.count, 513)
-            freePolyline2D(&polyline)
+            for _ in 0..<100 {
+                var polyline = getAdaptiveQuadraticBezierPath2(.init(0, 0), .init(1,0), .init(0,1), 0.001)
+                XCTAssertEqual(polyline.count, 513)
+                freePolyline2D(&polyline)
+            }
+        }
+    }
+
+    func _adaptiveQuadBezierCurve2(_ a: SIMD2<Float>,
+                                   _ b: SIMD2<Float>,
+                                   _ c: SIMD2<Float>,
+                                   _ aVel: SIMD2<Float>,
+                                   _ bVel: SIMD2<Float>,
+                                   _ cVel: SIMD2<Float>,
+                                   _ angleLimit: Float,
+                                   _ depth: Int,
+                                   _ pts: inout [SIMD2<Float>]) {
+
+        if depth > 8 { return }
+
+        let startMiddleAngle = acos(simd_dot(aVel, bVel))
+        let middleEndAngle = acos(simd_dot(bVel, cVel))
+
+        if (startMiddleAngle + middleEndAngle) > angleLimit {
+            // Split curve into two curves (start, end)
+
+            let ab = (a + b) * 0.5;
+            let bc = (b + c) * 0.5;
+            let abc = (ab + bc) * 0.5;
+
+            // Start Curve:  a,      ab,     abc
+            // End Curve:    abc,    bc,     c
+
+            let sVel = simd_normalize(quadraticBezierVelocity2(a, ab, abc, 0.5))
+
+            _adaptiveQuadBezierCurve2(a, ab, abc, aVel, sVel, bVel, angleLimit,
+                                                           depth + 1, &pts)
+            pts.append(abc)
+
+            let eVel = simd_normalize(quadraticBezierVelocity2(abc, bc, c, 0.5));
+            _adaptiveQuadBezierCurve2(abc, bc, c, bVel, eVel, cVel, angleLimit, depth + 1, &pts)
+        }
+
+    }
+
+    func getAdaptiveQuadBezierPath2(_ a: SIMD2<Float>,
+                                    _ b: SIMD2<Float>,
+                                    _ c: SIMD2<Float>,
+                                    _ angleLimit: Float) -> [SIMD2<Float>] {
+        let aVel = simd_normalize(quadraticBezierVelocity2(a, b, c, 0.0));
+        let bVel = simd_normalize(quadraticBezierVelocity2(a, b, c, 0.5));
+        let cVel = simd_normalize(quadraticBezierVelocity2(a, b, c, 1.0));
+
+        var pts: [SIMD2<Float>] = []
+        pts.reserveCapacity(513)
+        pts.append(a)
+
+        _adaptiveQuadBezierCurve2(a, b, c, aVel, bVel, cVel, angleLimit, 0, &pts);
+
+        pts.append(c)
+
+        return pts
+    }
+
+    func testAdaptiveQuadBezierPath2Perf() {
+        self.measure {
+            for _ in 0..<100 {
+                let polyline = getAdaptiveQuadBezierPath2(.init(0, 0), .init(1,0), .init(0,1), 0.001)
+                XCTAssertEqual(polyline.count, 513)
+            }
         }
     }
 

--- a/Tests/SatinCoreTests/BezierTests.swift
+++ b/Tests/SatinCoreTests/BezierTests.swift
@@ -11,6 +11,7 @@ import simd
 
 class BezierTests: XCTestCase {
 
+    // 0.008 in release mode
     func testAdaptiveQuadraticBezierPath2Perf() {
         self.measure {
             for _ in 0..<100 {
@@ -77,6 +78,7 @@ class BezierTests: XCTestCase {
         return pts
     }
 
+    // 0.002 in release mode.
     func testAdaptiveQuadBezierPath2Perf() {
         self.measure {
             for _ in 0..<100 {

--- a/Tests/SatinCoreTests/BezierTests.swift
+++ b/Tests/SatinCoreTests/BezierTests.swift
@@ -34,8 +34,8 @@ class BezierTests: XCTestCase {
 
         if depth > 8 { return }
 
-        let startMiddleAngle = acos(simd_dot(aVel, bVel))
-        let middleEndAngle = acos(simd_dot(bVel, cVel))
+        let startMiddleAngle = acos(dot(aVel, bVel))
+        let middleEndAngle = acos(dot(bVel, cVel))
 
         if (startMiddleAngle + middleEndAngle) > angleLimit {
             // Split curve into two curves (start, end)
@@ -63,9 +63,9 @@ class BezierTests: XCTestCase {
                                     _ b: SIMD2<Float>,
                                     _ c: SIMD2<Float>,
                                     _ angleLimit: Float) -> [SIMD2<Float>] {
-        let aVel = simd_normalize(quadraticBezierVelocity2(a, b, c, 0.0));
-        let bVel = simd_normalize(quadraticBezierVelocity2(a, b, c, 0.5));
-        let cVel = simd_normalize(quadraticBezierVelocity2(a, b, c, 1.0));
+        let aVel = normalize(quadraticBezierVelocity2(a, b, c, 0.0));
+        let bVel = normalize(quadraticBezierVelocity2(a, b, c, 0.5));
+        let cVel = normalize(quadraticBezierVelocity2(a, b, c, 1.0));
 
         var pts: [SIMD2<Float>] = []
         pts.reserveCapacity(513)


### PR DESCRIPTION
Shows that equivalent Swift code is 4x performance due to reduced allocation.