### PR TITLE
ensure deterministic test result

### DIFF
--- a/Tests/SatinCoreTests/MD5.swift
+++ b/Tests/SatinCoreTests/MD5.swift
@@ -1,0 +1,30 @@
+//
+//  MD5.swift
+//  
+//
+//  Created by Taylor Holliday on 3/26/22.
+//
+
+import Foundation
+import CryptoKit
+
+func MD5(data: Data) -> String {
+    let digest = Insecure.MD5.hash(data: data)
+
+    return digest.map {
+        String(format: "%02hhx", $0)
+    }.joined()
+}
+
+func MD5<T>(ptr: UnsafeMutablePointer<T>, count: Int) -> String {
+    MD5(data: Data(bytesNoCopy: UnsafeMutableRawPointer(ptr), count: count * MemoryLayout<T>.stride, deallocator: .none))
+}
+
+func MD5<T>(array: [T]) -> String {
+    var hash = Insecure.MD5()
+    array.withUnsafeBytes { hash.update(bufferPointer: $0) }
+    let digest = hash.finalize()
+    return digest.map {
+        String(format: "%02hhx", $0)
+    }.joined()
+}

--- a/Tests/SatinCoreTests/TriangulatorTests.swift
+++ b/Tests/SatinCoreTests/TriangulatorTests.swift
@@ -7,28 +7,6 @@
 
 import XCTest
 import SatinCore
-import CryptoKit
-
-func MD5(data: Data) -> String {
-    let digest = Insecure.MD5.hash(data: data)
-
-    return digest.map {
-        String(format: "%02hhx", $0)
-    }.joined()
-}
-
-func MD5<T>(ptr: UnsafeMutablePointer<T>, count: Int) -> String {
-    MD5(data: Data(bytesNoCopy: UnsafeMutableRawPointer(ptr), count: count * MemoryLayout<T>.stride, deallocator: .none))
-}
-
-func MD5<T>(array: [T]) -> String {
-    var hash = Insecure.MD5()
-    array.withUnsafeBytes { hash.update(bufferPointer: $0) }
-    let digest = hash.finalize()
-    return digest.map {
-        String(format: "%02hhx", $0)
-    }.joined()
-}
 
 class TriangulatorTests: XCTestCase {
     


### PR DESCRIPTION
Noticed that the MD5 result was different in debug vs release on my machine. Vertex contains a float3 which has an extra four bytes at the end for alignment.